### PR TITLE
コミットメッセージの種類を追加

### DIFF
--- a/.cz-config.cts
+++ b/.cz-config.cts
@@ -33,7 +33,11 @@ const config = {
       value: ':lipstick: style',
     },
     {
-      name: 'docs:     📝 ドキュメンテーションの追加/更新',
+      name: 'type:     🏷️  型の追加/更新',
+      value: ':label: type',
+    },
+    {
+      name: 'docs:     📝 ドキュメンテーションやコメントの追加/更新',
       value: ':memo: docs',
     },
     {

--- a/.cz-config.cts
+++ b/.cz-config.cts
@@ -69,6 +69,7 @@ const config = {
   },
   skipQuestions: ['scope', 'breaking', 'footer'],
   subjectLimit: 100,
+  upperCaseSubject: true,
 };
 
 module.exports = config;

--- a/commitlint.config.cts
+++ b/commitlint.config.cts
@@ -22,6 +22,7 @@ const config = {
         'WIP',
       ],
     ],
+    'type-case': [0, 'always', 'lower-case'],
   },
 };
 

--- a/commitlint.config.cts
+++ b/commitlint.config.cts
@@ -14,6 +14,7 @@ const config = {
         'refactor',
         'delete',
         'style',
+        'type',
         'docs',
         'move',
         'test',


### PR DESCRIPTION
## やったこと

- 型定義ファイルのみを変更した場合に使えるようなprefixを追加
- prefixに大文字を選べなかったバグを修正
- コミットメッセージをアルファベットの大文字で書き始めると小文字になってしまう仕様の修正